### PR TITLE
Fix docs for wrapped functions

### DIFF
--- a/aiohttp_apischema/generator.py
+++ b/aiohttp_apischema/generator.py
@@ -236,7 +236,7 @@ class SchemaGenerator:
                     handler = cast(Callable[[web.Request, Any], Awaitable[_Resp]], handler)
                     return await handler(request, request_body)
 
-                self._endpoints[wrapper] = {"meths": {None: ep_data}}
+                self._endpoints[wrapper.__wrapped__.__code__] = {"meths": {None: ep_data}}
                 return wrapper
 
             handler = cast(Callable[[web.Request], Awaitable[_Resp]], handler)
@@ -250,8 +250,11 @@ class SchemaGenerator:
         models: List[Tuple[Tuple[str, OpenAPIMethod, Union[int, Literal["requestBody"]]], Literal["serialization", "validation"], TypeAdapter[object]]] = []
         paths: Dict[str, _PathObject] = {}
         for route in app.router.routes():
+            handler = route.handler
+            if hasattr(handler, "__wrapped__"):
+                handler = handler.__wrapped__
             try:
-                ep_data = self._endpoints.get(route.handler.__code__)
+                ep_data = self._endpoints.get(handler.__code__)
             except AttributeError:
                 continue
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -104,7 +104,6 @@ async def test_response(aiohttp_client: AiohttpClient) -> None:
     assert schema["paths"] == paths
 
 
-@pytest.mark.xfail(reason="Regression introduced in 7e96c50f6")
 async def test_body(aiohttp_client: AiohttpClient) -> None:
     schema_gen = SchemaGenerator()
 


### PR DESCRIPTION
In #2 we changed the lookup to use the functions' `__code__` attribute, so we could use non-static methods. But we missed another place where we should have switched from the function to the `__code__` attribute, and that made some functions not be discoverable by the schema generator.
